### PR TITLE
Fix memory leak in strFtoC

### DIFF
--- a/src/interface.cxx
+++ b/src/interface.cxx
@@ -77,6 +77,8 @@ std::string strFtoC(const char *str, int len)
     char *tstr = new char[tlen+1];
     strncpy(tstr, str, tlen);
     tstr[tlen] = '\0';
+    std::string ret = std::string(tstr);
 
-    return std::string(tstr);
+    delete [] tstr;
+    return ret;
 }//strFtoC


### PR DESCRIPTION
I know this repo hasn't been committed to for a while, but it's used by the GiBUU neutrino Monte Carlo simulation as the ROOT interface (https://gibuu.hepforge.org/trac/wiki/libRootTuple), and the memory leak was problematic for generating large numbers of events.